### PR TITLE
MCPのspotifyサーバーを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 dist/
+
+.env

--- a/compose.yml
+++ b/compose.yml
@@ -15,6 +15,8 @@ services:
       - "3000:3000"
     depends_on:
       - ollama
+    env_file:
+      - .env 
     develop:
       watch:
         - path: ./

--- a/index.ts
+++ b/index.ts
@@ -100,7 +100,7 @@ const query = async (client: Ollama, model: string, mcpTools: McpTools, prompt: 
 }
 
 // Ollama サーバーが起動するまで待機する関数
-async function waitForOllama(host: string, retries = 30, delay = 1000) {
+export async function waitForOllama(host: string, retries = 30, delay = 1000) {
   for (let i = 0; i < retries; i++) {
     try {
       const res = await fetch(`${host}/v1/models`);

--- a/index.ts
+++ b/index.ts
@@ -114,19 +114,11 @@ export async function waitForOllama(host: string, retries = 30, delay = 1000) {
 
 // メイン処理
 async function main() {
-  const host = "http://ollama:11434";
+  const host = process.env.OLLAMA_HOST || "http://localhost:11434";
   await waitForOllama(host); // Ollama が起動するまで待つ
-
-  const client = new Ollama({ host });
 
   // MCP サーバー（時刻・天気）を登録
   const mcpTools = await getMcpTools([TimeServer, WeatherServer]);
-  const model = "qwen2:0.5b";
-
-  // モデル + ツールを組み合わせて質問する
-  await query(client, model, mcpTools, "東京の天気は？");
-  await query(client, model, mcpTools, "今日の青森と千葉の天気は？");
-  await query(client, model, mcpTools, "今日は何曜日？");
 
   // 後処理
   await mcpTools.close();

--- a/mcp-servers/search-track.ts
+++ b/mcp-servers/search-track.ts
@@ -17,6 +17,80 @@ async function getAccessToken() {
   return data.access_token as string;
 }
 
+async function classifyQuery(query: string) {
+  console.log("=== Ollama Classify ===");
+  console.log("入力クエリ:", query);
+  console.log("使用モデル:", OLLAMA_MODEL);
+
+  const prompt = `
+あなたはSpotify検索用の分類アシスタントです。
+ユーザーの入力に応じて、検索タイプを以下のカテゴリに分類してください:
+- "track"（曲）
+- "artist"（アーティスト）
+- "album"（アルバム）
+
+出力は必ず JSON 形式のみで、以下のキーを持たせてください:
+{
+  "type": <カテゴリ>,
+  "keyword": <検索に使うキーワード>
+}
+
+例をいくつか示します:
+
+入力: "Lemon"
+出力: {"type": "track", "keyword": "Lemon"}
+
+入力: "米津玄師"
+出力: {"type": "artist", "keyword": "米津玄師"}
+
+入力: "Lemon 米津玄師"
+出力: {"type": "track", "keyword": "Lemon 米津玄師"}
+
+入力: "アルバム STRAY SHEEP"
+出力: {"type": "album", "keyword": "STRAY SHEEP"}
+
+入力: "宇多田ヒカル First Love"
+出力: {"type": "album", "keyword": "First Love"}
+
+入力: "${query}"
+出力:
+`;
+
+
+  try {
+    await waitForOllama(OLLAMA_HOST); // Ollama が起動するまで待つ
+
+    const response = await ollama.chat({
+      model: OLLAMA_MODEL,
+      messages: [{ role: "user", content: prompt }],
+    });
+
+    console.log("Classify raw response:", response);
+
+    if (!response?.message?.content) {
+      console.warn("⚠ Ollama 応答に content がありません。fallback に移行します");
+      return { type: "track", keyword: query };
+    }
+
+    try {
+      let content = response.message.content;
+
+      // ```json ... ``` のコードブロックを除去
+      content = content.replace(/```json\s*([\s\S]*?)```/i, '$1').trim();
+
+      const json = JSON.parse(content);
+      console.log("Classify parsed JSON:", json);
+      return json;
+    } catch (parseErr) {
+      console.error("⚠ JSON parse error:", parseErr);
+      return { type: "track", keyword: query }; // fallback
+    }
+  } catch (err) {
+    console.error("⚠ Ollama API 呼び出しエラー:", err);
+    return { type: "track", keyword: query }; // fallback
+  }
+}
+
 const server = new McpServer({
   name: "Spotifyサーバー",
   version: "1.0.0",
@@ -30,22 +104,32 @@ server.tool(
     query: z.string({ description: "検索したい曲名やアーティスト名" }),
   },
   async ({ query }) => {
+    const { type, keyword } = await classifyQuery(query);
+
     const token = await getAccessToken();
     const res = await fetch(
-      `https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=track&limit=3`,
+      `https://api.spotify.com/v1/search?q=${encodeURIComponent(
+        keyword
+      )}&type=${type}&limit=3`,
       {
         headers: { Authorization: `Bearer ${token}` },
       }
     );
     const data = await res.json();
 
-    console.log("Spotify API response:", JSON.stringify(data, null, 2)); // ← デバッグ出力
-
-
-    const tracks = data.tracks.items.map((track: any) => {
-      const artists = track.artists.map((a: any) => a.name).join(", ");
-      return `${track.name} - ${artists} (${track.external_urls.spotify})`;
-    });
+    const items =
+      data[type + "s"].items.map((item: any) => {
+        if (type === "track") {
+          const artists = item.artists.map((a: any) => a.name).join(", ");
+          return `${item.name} - ${artists} (${item.external_urls.spotify})`;
+        } else if (type === "artist") {
+          return `Artist: ${item.name} (${item.external_urls.spotify})`;
+        } else if (type === "album") {
+          return `Album: ${item.name} - ${item.artists
+            .map((a: any) => a.name)
+            .join(", ")} (${item.external_urls.spotify})`;
+        }
+      }) ?? [];
 
     return {
       content: [{ type: "text", text: tracks.join("\n") }],

--- a/mcp-servers/search-track.ts
+++ b/mcp-servers/search-track.ts
@@ -1,0 +1,57 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+const CLIENT_ID = process.env.SPOTIFY_CLIENT_ID!;
+const CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET!;
+
+async function getAccessToken() {
+  const res = await fetch("https://accounts.spotify.com/api/token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "Authorization": "Basic " + Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString("base64"),
+    },
+    body: "grant_type=client_credentials",
+  });
+  const data = await res.json();
+  console.log("AccessToken response:", data); // ← 追加
+  return data.access_token as string;
+}
+
+const server = new McpServer({
+  name: "Spotifyサーバー",
+  version: "1.0.0",
+});
+
+// 曲検索ツール
+server.tool(
+  "search-track",
+  "Spotifyで曲を検索する",
+  {
+    query: z.string({ description: "検索したい曲名やアーティスト名" }),
+  },
+  async ({ query }) => {
+    const token = await getAccessToken();
+    const res = await fetch(
+      `https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=track&limit=3`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
+    const data = await res.json();
+
+    console.log("Spotify API response:", JSON.stringify(data, null, 2)); // ← デバッグ出力
+
+
+    const tracks = data.tracks.items.map((track: any) => {
+      const artists = track.artists.map((a: any) => a.name).join(", ");
+      return `${track.name} - ${artists} (${track.external_urls.spotify})`;
+    });
+
+    return {
+      content: [{ type: "text", text: tracks.join("\n") }],
+    };
+  }
+);
+
+export const SpotifyServer = server;

--- a/mcp-servers/search-track.ts
+++ b/mcp-servers/search-track.ts
@@ -1,8 +1,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { Ollama } from "ollama";
+import { waitForOllama } from "../index.js";
 
 const CLIENT_ID = process.env.SPOTIFY_CLIENT_ID!;
 const CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET!;
+const OLLAMA_MODEL = process.env.OLLAMA_MODEL || "";
+const OLLAMA_HOST = process.env.OLLAMA_HOST || "http://localhost:11434";
+
+const ollama = new Ollama({ host: OLLAMA_HOST });
 
 async function getAccessToken() {
   const res = await fetch("https://accounts.spotify.com/api/token", {
@@ -132,7 +138,7 @@ server.tool(
       }) ?? [];
 
     return {
-      content: [{ type: "text", text: tracks.join("\n") }],
+      content: [{ type: "text", text: items.join("\n") }],
     };
   }
 );

--- a/mcp-servers/search-track.ts
+++ b/mcp-servers/search-track.ts
@@ -14,7 +14,7 @@ async function getAccessToken() {
     body: "grant_type=client_credentials",
   });
   const data = await res.json();
-  console.log("AccessToken response:", data); // ← 追加
+  console.log("AccessToken response:", data);
   return data.access_token as string;
 }
 

--- a/mcp-servers/search-track.ts
+++ b/mcp-servers/search-track.ts
@@ -15,7 +15,9 @@ async function getAccessToken() {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
-      "Authorization": "Basic " + Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString("base64"),
+      "Authorization":
+        "Basic " +
+        Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString("base64"),
     },
     body: "grant_type=client_credentials",
   });

--- a/mcp-servers/search-track.ts
+++ b/mcp-servers/search-track.ts
@@ -14,7 +14,6 @@ async function getAccessToken() {
     body: "grant_type=client_credentials",
   });
   const data = await res.json();
-  console.log("AccessToken response:", data);
   return data.access_token as string;
 }
 

--- a/server.ts
+++ b/server.ts
@@ -4,12 +4,14 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { DirectServerTransport } from "./libs/direct-transport.js";
 import { WeatherServer } from "./mcp-servers/get-weather.js";
 import { TimeServer } from "./mcp-servers/get-current-time.js";
+import { SpotifyServer } from "./mcp-servers/search-track.js";
+
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 
-const servers = [WeatherServer, TimeServer];
+const servers = [WeatherServer, TimeServer, SpotifyServer];
 const clients: Record<string, Client> = {};
 
 (async () => {


### PR DESCRIPTION
spotifyリンクをLLMで聞ける機能追加

`compose.yml` ファイルと同階層に `.env` ファイルを追加。
## 1. `.env` ファイルの内容
```
SPOTIFY_CLIENT_ID=your_client_id
SPOTIFY_CLIENT_SECRET=your_client_secret
OLLAMA_MODEL=qwen2.5-coder:7b
OLLAMA_HOST=http://ollama:11434
```

## ollamaモデルの追加
1. `docker compose up --build`で起動

2. `docker exec -it ollama ollama pull qwen2.5-coder:7b`で、
`qwen2.5-coder:7b`というモデルをollamaに追加

（以下で再起動したほうがいいかも）
`docker compose down`
`docker compose up --build`

## APIの叩き方
別のターミナルを開いて、以下のコマンドを実行
```
curl -X POST http://localhost:3000/api/tool/search-track
   -H "Content-Type: application/json"
   -d '{"query": "欅坂の曲を教えて"}'
```